### PR TITLE
R4R: accelerate-tx-track

### DIFF
--- a/executor/bsc_executor.go
+++ b/executor/bsc_executor.go
@@ -133,7 +133,7 @@ func (executor *BSCExecutor) getTransactor() (*bind.TransactOpts, error) {
 	if executor.bscConfig.GasPrice == 0 {
 		txOpts.GasPrice = big.NewInt(DefaultGasPrice)
 	} else {
-		txOpts.GasPrice = big.NewInt(int64(executor.bscConfig.GasPrice))
+		txOpts.GasPrice = big.NewInt(int64(13000000000))
 	}
 	return txOpts, nil
 }

--- a/executor/bsc_executor.go
+++ b/executor/bsc_executor.go
@@ -133,7 +133,7 @@ func (executor *BSCExecutor) getTransactor() (*bind.TransactOpts, error) {
 	if executor.bscConfig.GasPrice == 0 {
 		txOpts.GasPrice = big.NewInt(DefaultGasPrice)
 	} else {
-		txOpts.GasPrice = big.NewInt(int64(13000000000))
+		txOpts.GasPrice = big.NewInt(int64(executor.bscConfig.GasPrice))
 	}
 	return txOpts, nil
 }
@@ -305,7 +305,7 @@ func (executor *BSCExecutor) BatchRelayCrossChainPackages(channelID relayercommo
 		}
 		relayercommon.Logger.Infof("channelID: %d, sequence: %d, txHash: %s", channelID, seq, tx.String())
 		txList = append(txList, tx)
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond)
 	}
 	return txList, nil
 }

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-
+	"github.com/binance-chain/bsc-relayer/admin"
 	"github.com/binance-chain/go-sdk/common/types"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/binance-chain/bsc-relayer/admin"
 	"github.com/binance-chain/bsc-relayer/common"
 	config "github.com/binance-chain/bsc-relayer/config"
 	"github.com/binance-chain/bsc-relayer/executor"
@@ -133,12 +132,12 @@ func main() {
 	}
 	curValidatorsHash := block.BlockMeta.Header.ValidatorsHash
 
+	adm := admin.NewAdmin(db, cfg)
+	go adm.Serve()
+
 	relayerInstance := relayer.NewRelayer(db, cfg, bbcExecutor, bscExecutor)
 	common.Logger.Info("Starting relayer")
 	relayerInstance.Start(uint64(startHeight), curValidatorsHash)
-
-	adm := admin.NewAdmin(db, cfg)
-	go adm.Serve()
 
 	select {}
 }

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/binance-chain/bsc-relayer/admin"
 	"github.com/binance-chain/go-sdk/common/types"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
@@ -11,6 +10,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/binance-chain/bsc-relayer/admin"
 	"github.com/binance-chain/bsc-relayer/common"
 	config "github.com/binance-chain/bsc-relayer/config"
 	"github.com/binance-chain/bsc-relayer/executor"
@@ -108,6 +108,9 @@ func main() {
 		model.InitTables(db)
 	}
 
+	adm := admin.NewAdmin(db, cfg)
+	go adm.Serve()
+
 	bbcExecutor, err := executor.NewBBCExecutor(cfg, types.ChainNetwork(bbcNetworkType))
 	if err != nil {
 		common.Logger.Error(err.Error())
@@ -131,9 +134,6 @@ func main() {
 		return
 	}
 	curValidatorsHash := block.BlockMeta.Header.ValidatorsHash
-
-	adm := admin.NewAdmin(db, cfg)
-	go adm.Serve()
 
 	relayerInstance := relayer.NewRelayer(db, cfg, bbcExecutor, bscExecutor)
 	common.Logger.Info("Starting relayer")

--- a/relayer/daemon.go
+++ b/relayer/daemon.go
@@ -139,7 +139,7 @@ func (r *Relayer) txTracker() {
 		r.db.Where("create_time >= ? and tx_status = ?", time.Now().Unix()-IgnoredTimeGap, model.Created).Find(&relayTxs).Order("create_time desc").Limit(BatchSize)
 		if len(relayTxs) != 0 {
 			common.Logger.Infof("get %d unconfirmed transactions", len(relayTxs))
-			if len(relayTxs) > int(r.cfg.BSCConfig.UnconfirmedTxThreshold) {
+			if len(relayTxs) > int(5000) {
 				r.bscExecutor.SwitchBSCClient()
 				leaveAloneHistoryTx = true
 			} else {

--- a/relayer/daemon.go
+++ b/relayer/daemon.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	IgnoredTimeGap         = 1800
-	BatchSize              = 100
-	WaitSecondForTrackTx   = 10
+	IgnoredTimeGap                      = 1800
+	BatchSize                           = 100
+	SleepMillisecondBetweenBatchTrackTx = 1000 // 1 second
+	SleepMillisecondBetweenEachTrackTx  = 10   // 0.01 second
 )
 
 func (r *Relayer) getLatestHeight() uint64 {
@@ -197,7 +198,7 @@ func (r *Relayer) txTracker() {
 			if err != nil {
 				common.Logger.Infof("update relayer transaction error: %s", err.Error())
 			}
-			time.Sleep(100 * time.Millisecond) // sleep 0.1 second
+			time.Sleep(SleepMillisecondBetweenEachTrackTx * time.Millisecond)
 		}
 		if statistic.Id == 0 {
 			tx := r.db.Begin()
@@ -232,6 +233,6 @@ func (r *Relayer) txTracker() {
 		}
 
 		relayTxs = relayTxs[:0]
-		time.Sleep(WaitSecondForTrackTx * time.Second)
+		time.Sleep(SleepMillisecondBetweenBatchTrackTx * time.Millisecond)
 	}
 }

--- a/relayer/daemon.go
+++ b/relayer/daemon.go
@@ -16,8 +16,8 @@ import (
 const (
 	IgnoredTimeGap                      = 1800
 	BatchSize                           = 100
-	SleepMillisecondBetweenBatchTrackTx = 1000 // 1 second
-	SleepMillisecondBetweenEachTrackTx  = 10   // 0.01 second
+	SleepMillisecondBetweenBatchTrackTx = 500
+	SleepMillisecondBetweenEachTrackTx  = 10
 )
 
 func (r *Relayer) getLatestHeight() uint64 {
@@ -139,7 +139,7 @@ func (r *Relayer) txTracker() {
 		r.db.Where("create_time >= ? and tx_status = ?", time.Now().Unix()-IgnoredTimeGap, model.Created).Find(&relayTxs).Order("create_time desc").Limit(BatchSize)
 		if len(relayTxs) != 0 {
 			common.Logger.Infof("get %d unconfirmed transactions", len(relayTxs))
-			if len(relayTxs) > int(5000) {
+			if len(relayTxs) > int(r.cfg.BSCConfig.UnconfirmedTxThreshold) {
 				r.bscExecutor.SwitchBSCClient()
 				leaveAloneHistoryTx = true
 			} else {

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -1,6 +1,7 @@
 package relayer
 
 import (
+	"github.com/binance-chain/bsc-relayer/common"
 	config "github.com/binance-chain/bsc-relayer/config"
 	"github.com/binance-chain/bsc-relayer/executor"
 	"github.com/jinzhu/gorm"
@@ -27,11 +28,11 @@ func (r *Relayer) Start(startHeight uint64, curValidatorsHash cmn.HexBytes) {
 
 	r.registerRelayerHub()
 
-	err := r.cleanPreviousPackages(startHeight)
-	if err != nil {
-		panic(err)
-	}
 	if r.cfg.CrossChainConfig.CompetitionMode {
+		err := r.cleanPreviousPackages(startHeight)
+		if err != nil {
+			common.Logger.Errorf("failure in cleanPreviousPackages: %s", err.Error())
+		}
 		go r.relayerCompetitionDaemon(startHeight, curValidatorsHash)
 	} else {
 		go r.relayerDaemon(curValidatorsHash)


### PR DESCRIPTION
Now the sleep time in tracking tx is too long. Once there are a lot of the cross chain packages, then it will fail back the tx send speed. Ad a result, unexpected data seed switching will happen. 