### PR TITLE
R4R: Improve BSC Relayer Robust

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -153,6 +153,7 @@ type AlertConfig struct {
 	EnableHeartBeat bool  `json:"enable_heart_beat"`
 	Interval        int64 `json:"interval"`
 
+	Identity       string `json:"identity"`
 	TelegramBotId  string `json:"telegram_bot_id"`
 	TelegramChatId string `json:"telegram_chat_id"`
 

--- a/config/config.json
+++ b/config/config.json
@@ -51,6 +51,7 @@
     "enable_alert": true,
     "enable_heart_beat": false,
     "interval": 300,
+    "identity": "your_service_name",
     "telegram_bot_id": "your_bot_id",
     "telegram_chat_id": "your_chat_id",
     "balance_threshold": "1000000000000000000",

--- a/config/utils.go
+++ b/config/utils.go
@@ -47,7 +47,7 @@ func GetSecret(secretName, region string) (string, error) {
 	}
 }
 
-func SendTelegramMessage(botId string, chatId string, msg string) {
+func SendTelegramMessage(identity string, botId string, chatId string, msg string) {
 	if botId == "" || chatId == "" || msg == "" {
 		return
 	}
@@ -56,7 +56,7 @@ func SendTelegramMessage(botId string, chatId string, msg string) {
 	formData := url.Values{
 		"chat_id":    {chatId},
 		"parse_mode": {"html"},
-		"text":       {msg},
+		"text":       {fmt.Sprintf("%s: %s", identity, msg)},
 	}
 	_, err := http.PostForm(endPoint, formData)
 	if err != nil {

--- a/executor/bbc_executor.go
+++ b/executor/bbc_executor.go
@@ -129,9 +129,9 @@ func (executor *BBCExecutor) GetLatestBlockHeight(client rpc.Client) (int64, err
 
 func (executor *BBCExecutor) UpdateClients() {
 	for {
-		common.Logger.Infof("Start to monitor bc data-seeds' healthy")
+		common.Logger.Infof("Start to monitor bc data-seeds healthy")
 		for _, bbcClient := range executor.BBCClients {
-			if time.Since(bbcClient.UpdatedAt) > DataSeedDenyServiceThreshold {
+			if time.Since(bbcClient.UpdatedAt).Seconds() > DataSeedDenyServiceThreshold {
 				msg := fmt.Sprintf("data seed %s is not accessable", bbcClient.Provider)
 				common.Logger.Error(msg)
 				config.SendTelegramMessage(executor.Config.AlertConfig.Identity, executor.Config.AlertConfig.TelegramBotId, executor.Config.AlertConfig.TelegramChatId, msg)

--- a/executor/bbc_executor.go
+++ b/executor/bbc_executor.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/binance-chain/bsc-double-sign-sdk/client"
 	"github.com/binance-chain/bsc-double-sign-sdk/types/bsc"
@@ -23,10 +24,17 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
+type BBCClient struct {
+	BBCClient     *rpc.HTTP
+	Provider      string
+	CurrentHeight int64
+	UpdatedAt     time.Time
+}
+
 type BBCExecutor struct {
 	mutex         sync.RWMutex
 	clientIdx     int
-	RpcClients    []*rpc.HTTP
+	BBCClients    []*BBCClient
 	Config        *config.Config
 	keyManager    keys.KeyManager
 	sourceChainID common.CrossChainID
@@ -58,12 +66,15 @@ func getMnemonic(cfg *config.BBCConfig) (string, error) {
 	return mnemonic, nil
 }
 
-func initBBCClients(keyManager keys.KeyManager, providers []string, network ctypes.ChainNetwork) []*rpc.HTTP {
-	bcClients := make([]*rpc.HTTP, 0)
+func initBBCClients(keyManager keys.KeyManager, providers []string, network ctypes.ChainNetwork) []*BBCClient {
+	bcClients := make([]*BBCClient, 0)
 	for _, provider := range providers {
 		rpcClient := rpc.NewRPCClient(provider, network)
 		rpcClient.SetKeyManager(keyManager)
-		bcClients = append(bcClients, rpcClient)
+		bcClients = append(bcClients, &BBCClient{
+			BBCClient: rpcClient,
+			Provider:  provider,
+		})
 	}
 	return bcClients
 }
@@ -83,7 +94,7 @@ func NewBBCExecutor(cfg *config.Config, networkType ctypes.ChainNetwork) (*BBCEx
 
 	return &BBCExecutor{
 		clientIdx:     0,
-		RpcClients:    initBBCClients(keyManager, cfg.BBCConfig.RpcAddrs, networkType),
+		BBCClients:    initBBCClients(keyManager, cfg.BBCConfig.RpcAddrs, networkType),
 		keyManager:    keyManager,
 		Config:        cfg,
 		sourceChainID: common.CrossChainID(cfg.CrossChainConfig.SourceChainID),
@@ -94,17 +105,61 @@ func NewBBCExecutor(cfg *config.Config, networkType ctypes.ChainNetwork) (*BBCEx
 func (executor *BBCExecutor) GetClient() *rpc.HTTP {
 	executor.mutex.RLock()
 	defer executor.mutex.RUnlock()
-	return executor.RpcClients[executor.clientIdx]
+	return executor.BBCClients[executor.clientIdx].BBCClient
 }
 
 func (executor *BBCExecutor) SwitchBCClient() {
 	executor.mutex.Lock()
 	defer executor.mutex.Unlock()
 	executor.clientIdx++
-	if executor.clientIdx >= len(executor.RpcClients) {
+	if executor.clientIdx >= len(executor.BBCClients) {
 		executor.clientIdx = 0
 	}
 	common.Logger.Infof("Switch to RPC endpoint: %s", executor.Config.BBCConfig.RpcAddrs[executor.clientIdx])
+}
+
+func (executor *BBCExecutor) GetLatestBlockHeight(client rpc.Client) (int64, error) {
+	status, err := client.Status()
+	if err != nil {
+		return 0, err
+	}
+	return status.SyncInfo.LatestBlockHeight, nil
+}
+
+func (executor *BBCExecutor) UpdateClients() {
+	for {
+		common.Logger.Infof("start update BBC clients")
+		for _, bbcClient := range executor.BBCClients {
+			height, err := executor.GetLatestBlockHeight(bbcClient.BBCClient)
+			if err != nil {
+				common.Logger.Errorf("get latest block height error, err=%s", err.Error())
+				continue
+			}
+			if time.Since(bbcClient.UpdatedAt) > DataSeedDenyServiceThreshold {
+				msg := fmt.Sprintf("data seed %s is not accessable", bbcClient.Provider)
+				config.SendTelegramMessage(executor.Config.AlertConfig.Identity, executor.Config.AlertConfig.TelegramBotId, executor.Config.AlertConfig.TelegramChatId, msg)
+			}
+			bbcClient.CurrentHeight = height
+			bbcClient.UpdatedAt = time.Now()
+		}
+		highestHeight := int64(0)
+		highestIdx := 0
+		for idx := 0; idx < len(executor.BBCClients); idx++ {
+			if executor.BBCClients[idx].CurrentHeight > highestHeight {
+				highestHeight = executor.BBCClients[idx].CurrentHeight
+				highestIdx = idx
+			}
+		}
+		// current bbcClient block sync is fall behind, switch to the bbcClient with highest block height
+		if executor.BBCClients[executor.clientIdx].CurrentHeight+FallBehindThreshold < highestHeight {
+			func() {
+				executor.mutex.Lock()
+				defer executor.mutex.Unlock()
+				executor.clientIdx = highestIdx
+			}()
+		}
+		time.Sleep(SleepSecondForUpdateClient * time.Second)
+	}
 }
 
 func (executor *BBCExecutor) SubmitEvidence(headers []*bsc.Header) (*coretypes.ResultBroadcastTx, error) {

--- a/executor/bbc_executor.go
+++ b/executor/bbc_executor.go
@@ -154,11 +154,9 @@ func (executor *BBCExecutor) UpdateClients() {
 		}
 		// current bbcClient block sync is fall behind, switch to the bbcClient with highest block height
 		if executor.BBCClients[executor.clientIdx].CurrentHeight+FallBehindThreshold < highestHeight {
-			func() {
-				executor.mutex.Lock()
-				defer executor.mutex.Unlock()
-				executor.clientIdx = highestIdx
-			}()
+			executor.mutex.Lock()
+			executor.clientIdx = highestIdx
+			executor.mutex.Unlock()
 		}
 		time.Sleep(SleepSecondForUpdateClient * time.Second)
 	}

--- a/executor/bsc_executor.go
+++ b/executor/bsc_executor.go
@@ -170,11 +170,9 @@ func (executor *BSCExecutor) UpdateClients() {
 		}
 		// current client block sync is fall behind, switch to the client with highest block height
 		if executor.bscClients[executor.clientIdx].CurrentHeight+FallBehindThreshold < highestHeight {
-			func() {
-				executor.mutex.Lock()
-				defer executor.mutex.Unlock()
-				executor.clientIdx = highestIdx
-			}()
+			executor.mutex.Lock()
+			executor.clientIdx = highestIdx
+			executor.mutex.Unlock()
 		}
 		time.Sleep(SleepSecondForUpdateClient * time.Second)
 	}

--- a/executor/bsc_executor.go
+++ b/executor/bsc_executor.go
@@ -144,9 +144,9 @@ func (executor *BSCExecutor) GetLatestBlockHeight(client *ethclient.Client) (int
 
 func (executor *BSCExecutor) UpdateClients() {
 	for {
-		relayercommon.Logger.Infof("Start to monitor bsc data-seeds' healthy")
+		relayercommon.Logger.Infof("Start to monitor bsc data-seeds healthy")
 		for _, client := range executor.bscClients {
-			if time.Since(client.UpdatedAt) > DataSeedDenyServiceThreshold {
+			if time.Since(client.UpdatedAt).Seconds() > DataSeedDenyServiceThreshold {
 				msg := fmt.Sprintf("data seed %s is not accessable", client.Provider)
 				relayercommon.Logger.Error(msg)
 				config.SendTelegramMessage(executor.cfg.AlertConfig.Identity, executor.cfg.AlertConfig.TelegramBotId, executor.cfg.AlertConfig.TelegramChatId, msg)

--- a/executor/const.go
+++ b/executor/const.go
@@ -23,6 +23,10 @@ const (
 	CorssChainPackageInfoAttributeValue = "%d" + separator + "%d" + separator + "%d" // destChainID channelID sequence
 
 	DefaultGasPrice = 20000000000 // 20 GWei
+
+	FallBehindThreshold          = 5
+	SleepSecondForUpdateClient   = 10
+	DataSeedDenyServiceThreshold = 60
 )
 
 var (

--- a/relayer/alert.go
+++ b/relayer/alert.go
@@ -33,12 +33,12 @@ func (r *Relayer) alert() {
 				common.Logger.Error(err.Error())
 			}
 			if r.cfg.AlertConfig.EnableHeartBeat {
-				util.SendTelegramMessage(r.cfg.AlertConfig.TelegramBotId, r.cfg.AlertConfig.TelegramChatId, fmt.Sprintf("Info: heartbeat message: relayer balance: %s", balance.String()))
+				util.SendTelegramMessage(r.cfg.AlertConfig.Identity, r.cfg.AlertConfig.TelegramBotId, r.cfg.AlertConfig.TelegramChatId, fmt.Sprintf("Info: heartbeat message: relayer balance: %s", balance.String()))
 			}
 			if balance.Cmp(balanceThreshold) <= 0 {
 				msg := fmt.Sprintf("Alert: bsc-relayer balance (%s:BNB) on Binance Smart Chain is less than threshold (%s:BNB)",
 					balance.Div(decimal.NewFromInt(1e18)).String(), balanceThreshold.Div(decimal.NewFromInt(1e18)).String())
-				util.SendTelegramMessage(r.cfg.AlertConfig.TelegramBotId, r.cfg.AlertConfig.TelegramChatId, msg)
+				util.SendTelegramMessage(r.cfg.AlertConfig.Identity, r.cfg.AlertConfig.TelegramBotId, r.cfg.AlertConfig.TelegramChatId, msg)
 			}
 		}
 

--- a/relayer/claim_reward.go
+++ b/relayer/claim_reward.go
@@ -1,12 +1,10 @@
 package relayer
 
 import (
-	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/binance-chain/bsc-relayer/common"
-	util "github.com/binance-chain/bsc-relayer/config"
 )
 
 const (
@@ -28,7 +26,6 @@ func (r *Relayer) autoClaimRewardDaemon() {
 		}
 		common.Logger.Infof("The accumulated reward of bsc-relayer: %s", reward.String())
 		if reward.Cmp(minimumReward) >= 0 {
-			//rewardDecimals, err := decimal.NewFromString(reward.String())
 			if err != nil {
 				common.Logger.Errorf("Query bcs-relayer reward error: %s, ", err.Error())
 				continue
@@ -36,18 +33,10 @@ func (r *Relayer) autoClaimRewardDaemon() {
 
 			tx, err := r.bscExecutor.ClaimReward()
 			if err != nil {
-				common.Logger.Errorf("Claim bsc-relayer reward error: %s", err.Error())
-
-				msg := fmt.Sprintf("Encountered failure in trying to claim reward: %s", err.Error())
-				util.SendTelegramMessage(r.cfg.AlertConfig.TelegramBotId, r.cfg.AlertConfig.TelegramChatId, msg)
-
+				common.Logger.Errorf("Claim bsc-relayer reward error: %s, try again laster", err.Error())
 				continue
 			}
 			common.Logger.Infof("Claim bsc-relayer reward tx hash: %s", tx.String())
-
-			//msg := fmt.Sprintf("The accumulated reward of bsc-relayer is %s, try to claim reward, txhash: %s",
-			//	rewardDecimals.Div(decimal.NewFromInt(1e18)).String(), tx.String())
-			//util.SendTelegramMessage(r.cfg.AlertConfig.TelegramBotId, r.cfg.AlertConfig.TelegramChatId, msg)
 		}
 
 	}

--- a/relayer/cleanup.go
+++ b/relayer/cleanup.go
@@ -8,18 +8,19 @@ import (
 	"github.com/binance-chain/bsc-relayer/model"
 )
 
-func (r *Relayer) cleanPreviousPackages(height uint64) error {
+func (r *Relayer) cleanPreviousPackages(height uint64) (bool, error) {
 	blockSynced := false
+	needAccelerate := false
 	common.Logger.Infof("Cleanup packages at height %d", height)
 	for _, channelId := range r.bbcExecutor.Config.CrossChainConfig.MonitorChannelList {
 		nextSequence, err := r.bbcExecutor.GetNextSequence(common.CrossChainChannelID(channelId), int64(height))
 		if err != nil {
 			r.bbcExecutor.SwitchBCClient()
-			return err
+			return needAccelerate, err
 		}
 		nextDeliverSequence, err := r.bscExecutor.GetNextSequence(common.CrossChainChannelID(channelId))
 		if err != nil {
-			return err
+			return needAccelerate, err
 		}
 		//nextDeliveredSeqFromDB := r.calculateNextDeliverSeqFromDB(channelId)
 		//if nextDeliverSequence < nextDeliveredSeqFromDB {
@@ -28,25 +29,28 @@ func (r *Relayer) cleanPreviousPackages(height uint64) error {
 		common.Logger.Infof("channelID: %d, next deliver sequence %d on BSC, next sequence %d on BC",
 			channelId, nextDeliverSequence, nextSequence)
 		if nextSequence > nextDeliverSequence {
+			if nextSequence-nextDeliverSequence >= r.cfg.AlertConfig.SequenceGapThreshold / 2 { //Accelerate if the sequence gap reaches half of threshold
+				needAccelerate = true
+			}
 			if nextSequence-nextDeliverSequence >= r.cfg.AlertConfig.SequenceGapThreshold {
-				util.SendTelegramMessage(r.cfg.AlertConfig.TelegramBotId, r.cfg.AlertConfig.TelegramChatId,
+				util.SendTelegramMessage(r.cfg.AlertConfig.Identity, r.cfg.AlertConfig.TelegramBotId, r.cfg.AlertConfig.TelegramChatId,
 					fmt.Sprintf("Alert: channel %d, undelivered package quantity %d", channelId, nextSequence-nextDeliverSequence))
 			}
 			if !blockSynced {
 				tx, err := r.bscExecutor.SyncTendermintLightClientHeader(height + 1)
 				if err != nil {
-					return err
+					return needAccelerate, err
 				}
 				blockSynced = true
 				common.Logger.Infof("Sync header %d, txHash %s", height+1, tx.String())
 			}
 			_, err = r.bscExecutor.BatchRelayCrossChainPackages(common.CrossChainChannelID(channelId), nextDeliverSequence, nextSequence, height)
 			if err != nil {
-				return err
+				return needAccelerate, err
 			}
 		}
 	}
-	return nil
+	return needAccelerate, nil
 }
 
 func (r *Relayer) calculateNextDeliverSeqFromDB(channelID uint8) uint64 {

--- a/relayer/daemon.go
+++ b/relayer/daemon.go
@@ -18,6 +18,7 @@ const (
 	BatchSize                           = 100
 	SleepMillisecondBetweenBatchTrackTx = 500
 	SleepMillisecondBetweenEachTrackTx  = 10
+	HeightBehindThreshold               = 10
 )
 
 func (r *Relayer) getLatestHeight() uint64 {
@@ -102,6 +103,11 @@ func (r *Relayer) relayerDaemon(curValidatorsHash cmn.HexBytes) {
 	common.Logger.Info("Start relayer daemon in normal model")
 	needAccelerate := false
 	for {
+		// accelerate if block height fall behind
+		if currHeight := r.getLatestHeight(); currHeight > height+HeightBehindThreshold {
+			needAccelerate = true
+			height = currHeight
+		}
 		validatorSetChanged, curValidatorsHash, err = r.bbcExecutor.MonitorValidatorSetChange(int64(height), curValidatorsHash)
 		if err != nil {
 			sleepTime := time.Duration(r.bbcExecutor.Config.BBCConfig.SleepMillisecondForWaitBlock * int64(time.Millisecond))

--- a/relayer/double_sign_monitor.go
+++ b/relayer/double_sign_monitor.go
@@ -94,7 +94,7 @@ func (monitor *DoubleSignMonitor) doubleSignChecker(channelNumber int, header *e
 		signature1, _ := twoHeader[1].GetSignature()
 		common.Logger.Infof("found double sign evidence: height %d, first signature %s, second signature %s",
 			header.Number.Int64(), hex.EncodeToString(signature0), hex.EncodeToString(signature1))
-		util.SendTelegramMessage(monitor.bbcExecutor.Config.AlertConfig.TelegramBotId, monitor.bbcExecutor.Config.AlertConfig.TelegramChatId,
+		util.SendTelegramMessage(monitor.bbcExecutor.Config.AlertConfig.Identity, monitor.bbcExecutor.Config.AlertConfig.TelegramBotId, monitor.bbcExecutor.Config.AlertConfig.TelegramChatId,
 			fmt.Sprintf("Alert: found double sign evidence: height %d, first miner %s, signature %s; second miner %s, signature %s",
 				header.Number.Int64(), twoHeader[0].Coinbase.String(), hex.EncodeToString(signature0), twoHeader[1].Coinbase.String(), hex.EncodeToString(signature1)))
 

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -39,7 +39,7 @@ func (r *Relayer) Start(startHeight uint64, curValidatorsHash cmn.HexBytes) {
 	}
 
 	go r.bbcExecutor.UpdateClients()
-	go r.bscExecutor.UpdateClients()
+	//go r.bscExecutor.UpdateClients()
 
 	go r.txTracker()
 

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -29,7 +29,7 @@ func (r *Relayer) Start(startHeight uint64, curValidatorsHash cmn.HexBytes) {
 	r.registerRelayerHub()
 
 	if r.cfg.CrossChainConfig.CompetitionMode {
-		err := r.cleanPreviousPackages(startHeight)
+		_, err := r.cleanPreviousPackages(startHeight)
 		if err != nil {
 			common.Logger.Errorf("failure in cleanPreviousPackages: %s", err.Error())
 		}
@@ -37,6 +37,9 @@ func (r *Relayer) Start(startHeight uint64, curValidatorsHash cmn.HexBytes) {
 	} else {
 		go r.relayerDaemon(curValidatorsHash)
 	}
+
+	go r.bbcExecutor.UpdateClients()
+	go r.bscExecutor.UpdateClients()
 
 	go r.txTracker()
 

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -39,7 +39,7 @@ func (r *Relayer) Start(startHeight uint64, curValidatorsHash cmn.HexBytes) {
 	}
 
 	go r.bbcExecutor.UpdateClients()
-	//go r.bscExecutor.UpdateClients()
+	go r.bscExecutor.UpdateClients()
 
 	go r.txTracker()
 


### PR DESCRIPTION
- Use local nonce in batch delivering
- Add service identity
- Monitor data seed lastest blocks, switch the current client if it fall behind
- Accelerate delivery if sequence gap is more then half of alert threshold