### PR TITLE
fix double sign check function

### DIFF
--- a/relayer/double_sign_monitor.go
+++ b/relayer/double_sign_monitor.go
@@ -37,7 +37,7 @@ func isDoubleSignHeaders(headers [2]*bsc.Header) bool {
 	if headers[0].Number != (headers[1].Number) {
 		return false
 	}
-	if bytes.Equal(headers[0].ParentHash[:], headers[1].ParentHash[:]) {
+	if !bytes.Equal(headers[0].ParentHash[:], headers[1].ParentHash[:]) {
 		return false
 	}
 	signature1, err := headers[0].GetSignature()


### PR DESCRIPTION
### Description

The double-signed check function is wrong about checking parent hashes.

### Rationale

If the header is double-signed, that should have the same parent hash.